### PR TITLE
refactor: 진지티어 반환 및 완두밭 로직 수정

### DIFF
--- a/src/main/java/com/gaplog/server/domain/user/api/SeriousnessApi.java
+++ b/src/main/java/com/gaplog/server/domain/user/api/SeriousnessApi.java
@@ -28,7 +28,7 @@ public class SeriousnessApi {
         try {
             SeriousnessDto seriousnessDTO = seriousnessService.getSeriousness(userId);
             return ResponseEntity.ok(seriousnessDTO);
-        } catch (EntityNotFoundException e){
+        } catch (EntityNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
     }

--- a/src/main/java/com/gaplog/server/domain/user/application/SeriousnessService.java
+++ b/src/main/java/com/gaplog/server/domain/user/application/SeriousnessService.java
@@ -60,7 +60,12 @@ public class SeriousnessService {
         Seriousness seriousness = seriousnessRepository.findByUserId(userId)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid user ID: " + userId));
 
-        return SeriousnessDto.from(seriousness);
+        int totalSeriousnessCount = postRepository.findByUserId(userId)
+                .stream()
+                .mapToInt(Post::getSeriousnessCount)
+                .sum();
+
+        return SeriousnessDto.from(seriousness, totalSeriousnessCount);
     }
 
 }

--- a/src/main/java/com/gaplog/server/domain/user/application/SeriousnessService.java
+++ b/src/main/java/com/gaplog/server/domain/user/application/SeriousnessService.java
@@ -38,16 +38,17 @@ public class SeriousnessService {
 
 
     @Transactional(readOnly = true)
-    public List<SeriousnessFieldResponse> getSeriousnessField(Long userId){
-        // 유저가 작성한 포스와 진지 버튼 수 반환 (<- 완두밭 만들기 위해서)
+    public List<SeriousnessFieldResponse> getSeriousnessField(Long userId) {
+        // 유저가 작성한 포스트와 해당 포스트의 진지 버튼 수를 날짜별로 반환
         List<Post> posts = postRepository.findByUserId(userId);
-        Map<LocalDate, List<Post>> postsByDate = posts.stream()
-                .collect(Collectors.groupingBy(post -> post.getCreatedAt().toLocalDate()));
 
-        return postsByDate.entrySet().stream()
+        return posts.stream()
+                .collect(Collectors.groupingBy(post -> post.getCreatedAt().toLocalDate())) // 포스트 작성일 기준 그룹화
+                .entrySet().stream()
                 .map(entry -> {
                     LocalDate date = entry.getKey();
                     List<Post> postsOnDate = entry.getValue();
+                    // 해당 날짜에 작성된 모든 포스트가 받은 진지 버튼 수를 합산
                     int seriousnessCount = postsOnDate.stream().mapToInt(Post::getSeriousnessCount).sum();
                     int postCount = postsOnDate.size();
                     return new SeriousnessFieldResponse(date, seriousnessCount, postCount);

--- a/src/main/java/com/gaplog/server/domain/user/dto/SeriousnessDto.java
+++ b/src/main/java/com/gaplog/server/domain/user/dto/SeriousnessDto.java
@@ -1,29 +1,23 @@
 package com.gaplog.server.domain.user.dto;
 
+import com.gaplog.server.domain.user.domain.Seriousness;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-
-@Builder
 @Getter
-@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-@AllArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class SeriousnessDto {
-
     private Long seriousnessId;
     private Long userId;
     private int tier;
-    private LocalDate localDate;
+    private int seriousnessCount;
 
-    public static SeriousnessDto from(com.gaplog.server.domain.user.domain.Seriousness seriousness){
-        return SeriousnessDto.builder()
-                .seriousnessId(seriousness.getId())
-                .userId(seriousness.getUser().getId())
-                .tier(seriousness.getTier())
-                .localDate(seriousness.getLocalDate())
-                .build();
+    public static SeriousnessDto from(Seriousness seriousness, int totalSeriousnessCount) {
+        return new SeriousnessDto(
+                seriousness.getId(),
+                seriousness.getUser().getId(),
+                seriousness.getTier(),
+                totalSeriousnessCount
+        );
     }
 }


### PR DESCRIPTION
## 🐣Title

진지티어 반환 및 완두밭 로직 수정 

<br/>

## 🐣Part

BE

<br/>

## 🐣Key Changes

- 유저의 진지티어 반환 시 유저가 받은 총 진지버튼의 개수도 반환하도록 수정
- 완두밭 업데이트를 위해 포스트 게시 날짜를 기준으로 진지버튼 수가 반영되도록 수정

<br/>

## 🐣To Reviewer

- 프론트엔드에서 요청한 수정사항 작업 완료 

<br/>
